### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/hantsylabs/restexample/springmvc/ApiErrors.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/ApiErrors.java
@@ -11,4 +11,6 @@ public class ApiErrors {
 
     public static final String INVALID_REQUEST = PREFIX + "INVALID_REQUEST";
 
+    private ApiErrors() {}
+
 }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/Constants.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/Constants.java
@@ -14,4 +14,7 @@ public class Constants {
     public static final String URI_POSTS = "/posts";
 
     public static final String URI_COMMENTS = "/comments";
+
+    private Constants() {}
+
 }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/DTOUtils.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/DTOUtils.java
@@ -18,6 +18,8 @@ public class DTOUtils {
 
     private static final ModelMapper INSTANCE = new ModelMapper();
 
+    private DTOUtils() {}
+
     public static <S, T> T map(S source, Class<T> targetClass) {
         return INSTANCE.map(source, targetClass);
     }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/repository/PostSpecifications.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/repository/PostSpecifications.java
@@ -18,6 +18,8 @@ import org.springframework.util.StringUtils;
  */
 public class PostSpecifications {
 
+    private PostSpecifications() {}
+
     public static Specification<Post> filterByKeywordAndStatus(
             final String keyword,//
             final Post.Status status) {

--- a/src/main/java/com/hantsylabs/restexample/springmvc/repository/UserSpecifications.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/repository/UserSpecifications.java
@@ -18,6 +18,8 @@ import org.springframework.util.StringUtils;
  */
 public class UserSpecifications {
 
+    private UserSpecifications() {}
+
     public static Specification<User> filterUsersByKeyword(
             final String keyword,//
             final String role //

--- a/src/main/java/com/hantsylabs/restexample/springmvc/security/SecurityUtil.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/security/SecurityUtil.java
@@ -7,6 +7,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityUtil {
 
+    private SecurityUtil() {}
+
     public static User currentUser() {
         Authentication auth = SecurityContextHolder.getContext()
                 .getAuthentication();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava