### PR TITLE
Multiple code improvements - squid:S1192, squid:S1213, squid:S1488, squid:S2293, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/com/hantsylabs/restexample/springmvc/Application.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/Application.java
@@ -158,6 +158,7 @@ public class Application {
     @Order(-10)
     public static class SecurityConfig extends WebSecurityConfigurerAdapter {
 
+        public static final String ADMIN = "ADMIN";
         @Inject
         private UserRepository userRepository;
 
@@ -185,9 +186,9 @@ public class Application {
                     .and()
                         .authorizeRequests()
                         .regexMatchers(HttpMethod.GET, "^/api/users/[\\d]*(\\/)?$").authenticated()
-                        .regexMatchers(HttpMethod.GET, "^/api/users(\\/)?(\\?.+)?$").hasRole("ADMIN")
-                        .regexMatchers(HttpMethod.DELETE, "^/api/users/[\\d]*(\\/)?$").hasRole("ADMIN")
-                        .regexMatchers(HttpMethod.POST, "^/api/users(\\/)?$").hasRole("ADMIN")
+                        .regexMatchers(HttpMethod.GET, "^/api/users(\\/)?(\\?.+)?$").hasRole(ADMIN)
+                        .regexMatchers(HttpMethod.DELETE, "^/api/users/[\\d]*(\\/)?$").hasRole(ADMIN)
+                        .regexMatchers(HttpMethod.POST, "^/api/users(\\/)?$").hasRole(ADMIN)
                     .and()
                         .authorizeRequests()
                         .antMatchers("/api/**").authenticated()
@@ -225,8 +226,7 @@ public class Application {
 
         @Bean
         public BCryptPasswordEncoder passwordEncoder() {
-            BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-            return passwordEncoder;
+            return new BCryptPasswordEncoder();
         }
 
     }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/api/user/UserController.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/api/user/UserController.java
@@ -98,7 +98,7 @@ public class UserController {
         log.debug("check username existance by username @" + username);
 
         UserDetails userDetails = userService.findUserByUsername(username);
-        boolean found = (userDetails != null);
+        boolean found = userDetails != null;
         return new ResponseEntity<>(found, HttpStatus.OK);
     }
 

--- a/src/main/java/com/hantsylabs/restexample/springmvc/domain/Post.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/domain/Post.java
@@ -46,11 +46,6 @@ public class Post implements Serializable {
         PUBLISHED
     }
 
-    public Post(String title, String content) {
-        this.title = title;
-        this.content = content;
-    }
-    
     @Id()
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -84,5 +79,10 @@ public class Post implements Serializable {
     @Column(name = "last_modified_date")
     @CreatedDate
     private LocalDateTime lastModifiedDate;
+
+    public Post(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 
 }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/model/ResponseMessage.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/model/ResponseMessage.java
@@ -18,6 +18,8 @@ public class ResponseMessage {
     private String text;
     private String code;
 
+    private List<Error> errors = new ArrayList<>();
+
     public ResponseMessage(Type type, String text) {
         this.type = type;
         this.text = text;
@@ -56,8 +58,6 @@ public class ResponseMessage {
     public static ResponseMessage info(String text) {
         return new ResponseMessage(Type.info, text);
     }
-
-    private List<Error> errors = new ArrayList<Error>();
 
     public List<Error> getErrors() {
         return errors;

--- a/src/main/java/com/hantsylabs/restexample/springmvc/service/BlogService.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/service/BlogService.java
@@ -29,6 +29,8 @@ import org.springframework.util.Assert;
 public class BlogService {
 
     private static final Logger log = LoggerFactory.getLogger(BlogService.class);
+    public static final String POST_ID_CAN_NOT_BE_NULL = "post id can not be null";
+    public static final String FIND_POST_BY_ID = "find post by id@";
 
     @Inject
     private PostRepository postRepository;
@@ -65,7 +67,7 @@ public class BlogService {
     }
 
     public PostDetails updatePost(Long id, PostForm form) {
-        Assert.notNull(id, "post id can not be null");
+        Assert.notNull(id, POST_ID_CAN_NOT_BE_NULL);
 
         log.debug("updating post of @" + id + ", posst content @" + form);
 
@@ -80,9 +82,9 @@ public class BlogService {
     }
 
     public PostDetails findPostById(Long id) {
-        Assert.notNull(id, "post id can not be null");
+        Assert.notNull(id, POST_ID_CAN_NOT_BE_NULL);
 
-        log.debug("find post by id@" + id);
+        log.debug(FIND_POST_BY_ID + id);
 
         Post post = postRepository.findOne(id);
 
@@ -107,9 +109,9 @@ public class BlogService {
     }
 
     public CommentDetails saveCommentOfPost(Long id, CommentForm fm) {
-        Assert.notNull(id, "post id can not be null");
+        Assert.notNull(id, POST_ID_CAN_NOT_BE_NULL);
 
-        log.debug("find post by id@" + id);
+        log.debug(FIND_POST_BY_ID + id);
 
         Post post = postRepository.findOne(id);
 
@@ -131,9 +133,9 @@ public class BlogService {
     }
 
     public void deletePostById(Long id) {
-        Assert.notNull(id, "post id can not be null");
+        Assert.notNull(id, POST_ID_CAN_NOT_BE_NULL);
 
-        log.debug("find post by id@" + id);
+        log.debug(FIND_POST_BY_ID + id);
 
         Post post = postRepository.findOne(id);
 

--- a/src/main/java/com/hantsylabs/restexample/springmvc/service/UserService.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/service/UserService.java
@@ -31,6 +31,8 @@ import org.springframework.util.Assert;
 public class UserService {
 
     private static final Logger log = LoggerFactory.getLogger(UserService.class);
+    public static final String USER_ID_CAN_NOT_BE_NULL = "user id can not be null";
+    public static final String UPDATED_USER = "updated user @";
 
     @Inject
     private PasswordEncoder passwordEncoder;
@@ -83,7 +85,7 @@ public class UserService {
     }
 
     public UserDetails updateUser(Long id, UserForm form) {
-        Assert.notNull(id, "user id can not be null");
+        Assert.notNull(id, USER_ID_CAN_NOT_BE_NULL);
 
         log.debug("update user by id @" + id);
 
@@ -99,14 +101,14 @@ public class UserService {
         User updated = userRepository.save(user);
 
         if (log.isDebugEnabled()) {
-            log.debug("updated user @" + updated);
+            log.debug(UPDATED_USER + updated);
         }
 
         return DTOUtils.map(updated, UserDetails.class);
     }
 
     public void updatePassword(Long id, PasswordForm form) {
-        Assert.notNull(id, "user id can not be null");
+        Assert.notNull(id, USER_ID_CAN_NOT_BE_NULL);
 
         log.debug("update user password by id @" + id);
 
@@ -121,12 +123,12 @@ public class UserService {
         User saved = userRepository.save(user);
 
         if (log.isDebugEnabled()) {
-            log.debug("updated user @" + saved);
+            log.debug(UPDATED_USER + saved);
         }
     }
 
     public void updateProfile(Long id, ProfileForm form) {
-        Assert.notNull(id, "user id can not be null");
+        Assert.notNull(id, USER_ID_CAN_NOT_BE_NULL);
 
         log.debug("update profile for user @" + id + ", profile form@" + form);
 
@@ -137,12 +139,12 @@ public class UserService {
         User saved = userRepository.save(user);
 
         if (log.isDebugEnabled()) {
-            log.debug("updated user @" + saved);
+            log.debug(UPDATED_USER + saved);
         }
     }
 
     public UserDetails findUserById(Long id) {
-        Assert.notNull(id, "user id can not be null");
+        Assert.notNull(id, USER_ID_CAN_NOT_BE_NULL);
 
         log.debug("find user by id @" + id);
 
@@ -156,7 +158,7 @@ public class UserService {
     }
 
     public UserDetails findUserByUsername(String username) {
-        Assert.notNull(username, "user id can not be null");
+        Assert.notNull(username, USER_ID_CAN_NOT_BE_NULL);
 
         log.debug("find user by username @" + username);
 
@@ -170,7 +172,7 @@ public class UserService {
     }
 
     public void deleteUser(Long id) {
-        Assert.notNull(id, "user id can not be null");
+        Assert.notNull(id, USER_ID_CAN_NOT_BE_NULL);
 
         log.debug("delete user by id @" + id);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S2293 - The diamond operator ("<>") should be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava
