### PR TITLE
Added new Bower repository

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -2,5 +2,6 @@
     "scripts": {
         "postinstall": "node_modules/.bin/wiredep -s app/index.html"
     },
-    "directory": "app/bower_components"
+    "directory": "app/bower_components",
+    "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
Since older bower repository is not working. This can cause build failure. Hence switching to newer and recommended repo.

Reference Link : https://stackoverflow.com/questions/51020317/einvres-request-to-https-bower-herokuapp-com-packages-failed-with-502